### PR TITLE
Drop bundleFlavor in unified artifactId

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ implementation 'com.theoplayer.theoplayer-sdk-android:basic-minapi16:+'
 implementation 'com.theoplayer.theoplayer-sdk-android:basic-minapi21:+'
 implementation 'com.theoplayer.theoplayer-sdk-android:basic-androidTV:+'
 implementation 'com.theoplayer.theoplayer-sdk-android:basic-fireTV:+'
-implementation 'com.theoplayer.theoplayer-sdk-android:basic-unified:+'
+implementation 'com.theoplayer.theoplayer-sdk-android:unified:+'
 ```
 
 If you're targeting Android 5.0 and above, then you should only add the `minapi21` dependency.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ publishing {
                     // The reason why the order of the flavors are important in generating the publishing artifacts
                     def bundleFlavor = variant.flavors.name[0]
                     def apiFlavor = variant.flavors.name[1]
-                    artifactId "${bundleFlavor}-${apiFlavor}"
+                    artifactId apiFlavor == "unified" ? apiFlavor : "${bundleFlavor}-${apiFlavor}"
                     artifact("libs/${project.ext.sdkName}-${bundleFlavor}-${project.ext.sdkVersion}-${apiFlavor}-release.aar")
 
                     pom.withXml {


### PR DESCRIPTION
Drop bundleFlavor in 'unified' artifactId, resulting in:
`com.theoplayer.theoplayer-sdk-android:unified:<version>`